### PR TITLE
Improve contrast

### DIFF
--- a/src/App/Components/Collapsible.luau
+++ b/src/App/Components/Collapsible.luau
@@ -56,7 +56,7 @@ return function(props: Props): Frame
 
 	local color = animate(
 		Computed(function(use)
-			return use(Theme.Colors.ContrastBackground)
+			return use(isExpanded) and use(Theme.Colors.ActiveBackground) or use(Theme.Colors.Background)
 		end),
 		state
 	)

--- a/src/App/Components/Collapsible.luau
+++ b/src/App/Components/Collapsible.luau
@@ -56,7 +56,7 @@ return function(props: Props): Frame
 
 	local color = animate(
 		Computed(function(use)
-			return use(Theme.Colors.Background)
+			return use(Theme.Colors.ContrastBackground)
 		end),
 		state
 	)

--- a/src/App/Theme.luau
+++ b/src/App/Theme.luau
@@ -8,17 +8,20 @@ local Fusion = require(Argon.Packages.Fusion)
 local Value = Fusion.Value
 
 local function getColors(isDark: boolean): { [string]: { Color3 | { [string]: Color3 } } }
-	local border = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Shadow)
 	local background = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.MainBackground)
-
+	local border =
+		if background == Color3.fromRGB(46, 46, 46) then Color3.fromRGB(75, 75, 75)
+		elseif background == Color3.fromRGB(255, 255, 255) then Color3.fromRGB(220, 220, 220)
+		else Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Shadow)
+	
 	return {
 		-- It's actually 130, 120, 230
 		Brand = Color3.fromRGB(120, 110, 220),
 
 		Background = background,
+		ContrastBackground = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Mid),
 		ActiveBackground = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Titlebar),
-		Border = border ~= background and border
-			or Studio.Theme:GetColor(Enum.StudioStyleGuideColor.ScrollBarBackground),
+		Border = border,
 
 		Text = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.BrightText),
 		TextDimmed = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.SubText),
@@ -42,6 +45,7 @@ local Theme = {
 		Brand = init(),
 
 		Background = init(),
+		ContrastBackground = init(),
 		ActiveBackground = init(),
 		Border = init(),
 

--- a/src/App/Theme.luau
+++ b/src/App/Theme.luau
@@ -9,11 +9,11 @@ local Value = Fusion.Value
 
 local function getColors(isDark: boolean): { [string]: { Color3 | { [string]: Color3 } } }
 	local background = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.MainBackground)
-	local border =
-		if background == Color3.fromRGB(46, 46, 46) then Color3.fromRGB(75, 75, 75)
+	local border = if background == Color3.fromRGB(46, 46, 46)
+		then Color3.fromRGB(75, 75, 75)
 		elseif background == Color3.fromRGB(255, 255, 255) then Color3.fromRGB(220, 220, 220)
 		else Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Shadow)
-	
+
 	return {
 		-- It's actually 130, 120, 230
 		Brand = Color3.fromRGB(120, 110, 220),

--- a/src/App/Theme.luau
+++ b/src/App/Theme.luau
@@ -11,7 +11,7 @@ local function getColors(isDark: boolean): { [string]: { Color3 | { [string]: Co
 	local background = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.MainBackground)
 	local border = if background == Color3.fromRGB(46, 46, 46)
 		then Color3.fromRGB(75, 75, 75)
-		elseif background == Color3.fromRGB(255, 255, 255) then Color3.fromRGB(220, 220, 220)
+		elseif background == Color3.fromRGB(255, 255, 255) then Color3.fromHSV(0.000000, 0.000000, 0.862745)
 		else Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Shadow)
 
 	return {
@@ -21,7 +21,10 @@ local function getColors(isDark: boolean): { [string]: { Color3 | { [string]: Co
 		Background = background,
 		ContrastBackground = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Mid),
 		ActiveBackground = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Titlebar),
-		Border = border,
+		-- Fallback to ScrollBarBackground if custom themes use same color for background and shadow
+		Border = if background == border
+			then Studio.Theme:GetColor(Enum.StudioStyleGuideColor.ScrollBarBackground)
+			else border,
 
 		Text = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.BrightText),
 		TextDimmed = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.SubText),

--- a/src/App/Theme.luau
+++ b/src/App/Theme.luau
@@ -9,22 +9,22 @@ local Value = Fusion.Value
 
 local function getColors(isDark: boolean): { [string]: { Color3 | { [string]: Color3 } } }
 	local background = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.MainBackground)
-	local border = if background == Color3.fromRGB(46, 46, 46)
-		then Color3.fromRGB(75, 75, 75)
-		elseif background == Color3.fromRGB(255, 255, 255) then Color3.fromHSV(0.000000, 0.000000, 0.862745)
-		else Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Shadow)
+	local border = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Shadow)
+
+	if border == background then
+		border = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.ScrollBarBackground)
+	end
+
+	local h, s, v = border:ToHSV()
+	border = Color3.fromHSV(h, s, v * (isDark and 1.2 or 0.85))
 
 	return {
 		-- It's actually 130, 120, 230
 		Brand = Color3.fromRGB(120, 110, 220),
 
 		Background = background,
-		ContrastBackground = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Mid),
 		ActiveBackground = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.Titlebar),
-		-- Fallback to ScrollBarBackground if custom themes use same color for background and shadow
-		Border = if background == border
-			then Studio.Theme:GetColor(Enum.StudioStyleGuideColor.ScrollBarBackground)
-			else border,
+		Border = border,
 
 		Text = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.BrightText),
 		TextDimmed = Studio.Theme:GetColor(Enum.StudioStyleGuideColor.SubText),
@@ -48,7 +48,6 @@ local Theme = {
 		Brand = init(),
 
 		Background = init(),
-		ContrastBackground = init(),
 		ActiveBackground = init(),
 		Border = init(),
 

--- a/src/App/Widgets/Help.luau
+++ b/src/App/Widgets/Help.luau
@@ -33,7 +33,6 @@ end
 local function Header(text: string)
 	return Text {
 		Font = Theme.Fonts.Bold,
-		Color = Theme.Colors.Brand,
 		Text = text,
 	}
 end
@@ -43,6 +42,7 @@ local function Paragraph(text: string)
 		Text = text,
 		TextWrapped = true,
 		TextSize = Theme.TextSize.Small,
+		Color = Theme.Colors.TextDimmed,
 	}
 end
 
@@ -66,6 +66,7 @@ local function Link(text: string, url: string)
 						Text = url,
 						TextEditable = false,
 						TextSize = Theme.TextSize.Large,
+						Color = Theme.Colors.Brand,
 					},
 				},
 			},

--- a/src/App/Widgets/Help.luau
+++ b/src/App/Widgets/Help.luau
@@ -33,6 +33,7 @@ end
 local function Header(text: string)
 	return Text {
 		Font = Theme.Fonts.Bold,
+		Color = Theme.Colors.Brand,
 		Text = text,
 	}
 end
@@ -42,7 +43,6 @@ local function Paragraph(text: string)
 		Text = text,
 		TextWrapped = true,
 		TextSize = Theme.TextSize.Small,
-		Color = Theme.Colors.TextDimmed,
 	}
 end
 


### PR DESCRIPTION
Improve contrast in some parts of UI for better accessibility.

## 1. Borders
### before
![border before lighter](https://github.com/user-attachments/assets/11f7cd24-75e7-4653-97d0-ff3a1869be79)

### after
![border after darker](https://github.com/user-attachments/assets/8c3678f8-4e7a-4ea4-9771-9053095ac609)
![border after light darker](https://github.com/user-attachments/assets/0eec71b0-3eb4-4fd7-b34a-712c5559d6c6)

## 2. Collapsible
![collapsible light darker](https://github.com/user-attachments/assets/70581d9a-8945-49db-b4c0-88e9415c8403)
![collapsible dark darker](https://github.com/user-attachments/assets/5ea6abdf-2216-4820-a752-f14e5fa0b1df)

## 3. Help
This one, I'm not sure about. I made the headings purple because I felt the help menu looked like a wall of text, but it's kind of awkward.
![help 2](https://github.com/user-attachments/assets/3e23a89b-8f15-48c0-b586-f112006ad6b5)
