### PR TITLE
Added Diff function

### DIFF
--- a/src/App/Components/Collapsible.luau
+++ b/src/App/Components/Collapsible.luau
@@ -32,12 +32,14 @@ local peek = Fusion.peek
 
 local COMPONENT_ONLY_PROPS = {
 	"Title",
+	"Color",
 	"Expanded",
 	"Elements",
 }
 
 type Props = {
 	Title: string,
+	Color: Fusion.CanBeState<Color3>?,
 	Expanded: boolean?,
 	Elements: { Instance },
 }
@@ -108,16 +110,14 @@ return function(props: Props): Frame
 								TextSize = Theme.TextSize.Large,
 								TextXAlignment = Enum.TextXAlignment.Left,
 								Size = UDim2.fromScale(1, 1),
-								Color = Computed(function(use)
-									return use(Theme.Colors.Text)
-								end),
+								Color = props.Color or Theme.Colors.Text,
 							},
 							Image {
 								AnchorPoint = Vector2.new(1, 0.5),
 								Position = UDim2.fromScale(1, 0.5),
 								Size = UDim2.fromOffset(16, 16),
 								Image = Assets.Icons.Expand,
-								ImageColor3 = Theme.Colors.Text,
+								ImageColor3 = props.Color or Theme.Colors.Text,
 								Rotation = Spring(
 									Computed(function(use)
 										return use(isExpanded) and 180 or 0

--- a/src/App/Widgets/Diff.luau
+++ b/src/App/Widgets/Diff.luau
@@ -1,0 +1,270 @@
+local Argon = script:FindFirstAncestor("Argon")
+local App = Argon.App
+local Components = App.Components
+
+local Fusion = require(Argon.Packages.Fusion)
+
+local Theme = require(App.Theme)
+local Dom = require(Argon.Dom)
+local Types = require(Argon.Types)
+
+local Widget = require(Components.Plugin.Widget)
+local ScrollingContainer = require(Components.ScrollingContainer)
+local Container = require(Components.Container)
+local Padding = require(Components.Padding)
+local List = require(Components.List)
+local Text = require(Components.Text)
+local Box = require(Components.Box)
+
+local Children = Fusion.Children
+
+local function countChildren(snapshot: Types.Snapshot): number
+	local count = 0
+	if snapshot.children then
+		count = #snapshot.children
+		for _, child in snapshot.children do
+			count += countChildren(child)
+		end
+	end
+	return count
+end
+
+local function formatValue(encoded: any): string
+	local ok, decoded = Dom.EncodedValue.decode(encoded)
+	if ok then
+		local str = tostring(decoded)
+		if #str > 80 then
+			return str:sub(1, 77) .. "..."
+		end
+		return str
+	end
+	return "?"
+end
+
+local function formatSourceValue(encoded: any): string
+	local ok, decoded = Dom.EncodedValue.decode(encoded)
+	if ok and type(decoded) == "string" then
+		local lines = 0
+		for _ in decoded:gmatch("[^\n]*\n") do
+			lines += 1
+		end
+		if not decoded:find("\n$") and #decoded > 0 then
+			lines += 1
+		end
+		return `{lines} line{lines ~= 1 and "s" or ""}`
+	end
+	return formatValue(encoded)
+end
+
+local function readCurrentValue(instance: Instance, propertyName: string): string
+	local ok, value = Dom.readProperty(instance, propertyName)
+	if ok then
+		local str = tostring(value)
+		if #str > 80 then
+			return str:sub(1, 77) .. "..."
+		end
+		return str
+	end
+	return "?"
+end
+
+local function readCurrentSourceValue(instance: Instance, propertyName: string): string
+	local ok, value = Dom.readProperty(instance, propertyName)
+	if ok and type(value) == "string" then
+		local lines = 0
+		for _ in value:gmatch("[^\n]*\n") do
+			lines += 1
+		end
+		if not value:find("\n$") and #value > 0 then
+			lines += 1
+		end
+		return `{lines} line{lines ~= 1 and "s" or ""}`
+	end
+	return readCurrentValue(instance, propertyName)
+end
+
+local function isSourceProperty(propertyName: string): boolean
+	return propertyName == "Source"
+end
+
+local function SectionHeader(text: string, color: Color3)
+	return Container {
+		Size = UDim2.fromScale(1, 0),
+		[Children] = {
+			Padding {
+				Top = 4,
+				Bottom = 4,
+			},
+			Text {
+				Font = Theme.Fonts.Bold,
+				Text = text,
+				Color = color,
+				TextSize = Theme.TextSize.Medium,
+			},
+		},
+	}
+end
+
+local function AdditionEntry(snapshot: Types.AddedSnapshot)
+	local childCount = countChildren(snapshot)
+	local details = ""
+	if childCount > 0 then
+		details = `  ({childCount} descendant{childCount ~= 1 and "s" or ""})`
+	end
+
+	return Box {
+		Size = UDim2.fromScale(1, 0),
+		AutomaticSize = Enum.AutomaticSize.Y,
+		[Children] = {
+			Padding {},
+			Text {
+				Text = `+ [{snapshot.class}] "{snapshot.name}"{details}`,
+				Color = Theme.Colors.Diff.Add,
+				TextSize = Theme.TextSize.Small,
+				Font = Theme.Fonts.Mono,
+				TextWrapped = true,
+			},
+		},
+	}
+end
+
+local function PropertyLine(propertyName: string, currentValue: string, newValue: string)
+	return Text {
+		Text = `    {propertyName}: {currentValue} → {newValue}`,
+		Color = Theme.Colors.TextDimmed,
+		TextSize = Theme.TextSize.Small,
+		Font = Theme.Fonts.Mono,
+		TextWrapped = true,
+	}
+end
+
+local function UpdateEntry(snapshot: Types.UpdatedSnapshot, tree: any)
+	local instance = tree:getInstance(snapshot.id)
+	local name = if instance then instance.Name else (snapshot.name or "?")
+	local className = if instance then instance.ClassName else (snapshot.class or "?")
+
+	local children = {
+		Padding {},
+		List {
+			Spacing = 2,
+		},
+		Text {
+			Text = `~ [{className}] "{name}"`,
+			Color = Theme.Colors.Diff.Update,
+			TextSize = Theme.TextSize.Small,
+			Font = Theme.Fonts.Mono,
+			TextWrapped = true,
+		},
+	}
+
+	if snapshot.properties then
+		for propName, encodedValue in snapshot.properties do
+			local newVal
+			local curVal
+
+			if isSourceProperty(propName) then
+				newVal = formatSourceValue(encodedValue)
+				curVal = if instance then readCurrentSourceValue(instance, propName) else "?"
+			else
+				newVal = formatValue(encodedValue)
+				curVal = if instance then readCurrentValue(instance, propName) else "?"
+			end
+
+			table.insert(children, PropertyLine(propName, curVal, newVal))
+		end
+	end
+
+	if snapshot.name and instance and instance.Name ~= snapshot.name then
+		table.insert(children, PropertyLine("Name", instance.Name, snapshot.name))
+	end
+
+	return Box {
+		Size = UDim2.fromScale(1, 0),
+		AutomaticSize = Enum.AutomaticSize.Y,
+		[Children] = children,
+	}
+end
+
+local function RemovalEntry(ref: Types.Ref, tree: any)
+	local instance = tree:getInstance(ref)
+	local name = if instance then instance.Name else "?"
+	local className = if instance then instance.ClassName else "?"
+
+	return Box {
+		Size = UDim2.fromScale(1, 0),
+		AutomaticSize = Enum.AutomaticSize.Y,
+		[Children] = {
+			Padding {},
+			Text {
+				Text = `- [{className}] "{name}"`,
+				Color = Theme.Colors.Diff.Remove,
+				TextSize = Theme.TextSize.Small,
+				Font = Theme.Fonts.Mono,
+				TextWrapped = true,
+			},
+		},
+	}
+end
+
+type Props = {
+	Changes: Types.Changes,
+	Tree: any,
+	Closed: (() -> ())?,
+}
+
+return function(props: Props): DockWidgetPluginGui
+	local changes = props.Changes
+	local tree = props.Tree
+	local entries = {}
+
+	-- Additions
+	if #changes.additions > 0 then
+		table.insert(entries, SectionHeader(`Additions ({#changes.additions})`, Theme.Colors.Diff.Add))
+		for _, snapshot in changes.additions do
+			table.insert(entries, AdditionEntry(snapshot))
+		end
+	end
+
+	-- Updates
+	if #changes.updates > 0 then
+		table.insert(entries, SectionHeader(`Updates ({#changes.updates})`, Theme.Colors.Diff.Update))
+		for _, snapshot in changes.updates do
+			table.insert(entries, UpdateEntry(snapshot, tree))
+		end
+	end
+
+	-- Removals
+	if #changes.removals > 0 then
+		table.insert(entries, SectionHeader(`Removals ({#changes.removals})`, Theme.Colors.Diff.Remove))
+		for _, ref in changes.removals do
+			table.insert(entries, RemovalEntry(ref, tree))
+		end
+	end
+
+	return Widget {
+		Name = "Argon - Diff",
+		OverrideEnabled = true,
+		MinimumSize = Vector2.new(450, 400),
+		Closed = props.Closed,
+
+		[Children] = {
+			Padding {
+				Right = 4,
+			},
+
+			ScrollingContainer {
+				ScrollBar = true,
+
+				[Children] = {
+					List {
+						Spacing = 6,
+					},
+					Padding {
+						Padding = Theme.WidgetPadding,
+					},
+					entries,
+				},
+			},
+		},
+	}
+end

--- a/src/App/Widgets/Diff.luau
+++ b/src/App/Widgets/Diff.luau
@@ -41,19 +41,23 @@ local function formatValue(encoded: any): string
 	return "?"
 end
 
-local function formatSourceValue(encoded: any): string
+local function countLines(source: string): number
+	local lines = 0
+	for _ in source:gmatch("[^\n]*\n") do
+		lines += 1
+	end
+	if not source:find("\n$") and #source > 0 then
+		lines += 1
+	end
+	return lines
+end
+
+local function countSourceLines(encoded: any): number?
 	local ok, decoded = Dom.EncodedValue.decode(encoded)
 	if ok and type(decoded) == "string" then
-		local lines = 0
-		for _ in decoded:gmatch("[^\n]*\n") do
-			lines += 1
-		end
-		if not decoded:find("\n$") and #decoded > 0 then
-			lines += 1
-		end
-		return `{lines} line{lines ~= 1 and "s" or ""}`
+		return countLines(decoded)
 	end
-	return formatValue(encoded)
+	return nil
 end
 
 local function readCurrentValue(instance: Instance, propertyName: string): string
@@ -68,19 +72,12 @@ local function readCurrentValue(instance: Instance, propertyName: string): strin
 	return "?"
 end
 
-local function readCurrentSourceValue(instance: Instance, propertyName: string): string
+local function countCurrentSourceLines(instance: Instance, propertyName: string): number?
 	local ok, value = Dom.readProperty(instance, propertyName)
 	if ok and type(value) == "string" then
-		local lines = 0
-		for _ in value:gmatch("[^\n]*\n") do
-			lines += 1
-		end
-		if not value:find("\n$") and #value > 0 then
-			lines += 1
-		end
-		return `{lines} line{lines ~= 1 and "s" or ""}`
+		return countLines(value)
 	end
-	return readCurrentValue(instance, propertyName)
+	return nil
 end
 
 local function isSourceProperty(propertyName: string): boolean
@@ -159,18 +156,30 @@ local function UpdateEntry(snapshot: Types.UpdatedSnapshot, tree: any)
 
 	if snapshot.properties then
 		for propName, encodedValue in snapshot.properties do
-			local newVal
-			local curVal
-
-			if isSourceProperty(propName) then
-				newVal = formatSourceValue(encodedValue)
-				curVal = if instance then readCurrentSourceValue(instance, propName) else "?"
-			else
-				newVal = formatValue(encodedValue)
-				curVal = if instance then readCurrentValue(instance, propName) else "?"
+			local ty = next(encodedValue)
+			if ty == "Enum" then
+				continue
 			end
 
-			table.insert(children, PropertyLine(propName, curVal, newVal))
+			if isSourceProperty(propName) then
+				local newLines = countSourceLines(encodedValue)
+				local curLines = if instance then countCurrentSourceLines(instance, propName) else 0
+				if newLines and curLines then
+					local delta = newLines - curLines
+					local sign = if delta > 0 then "+" else ""
+					table.insert(children, Text {
+						Text = `    {propName}: {sign}{delta} line{math.abs(delta) ~= 1 and "s" or ""}`,
+						Color = Theme.Colors.TextDimmed,
+						TextSize = Theme.TextSize.Small,
+						Font = Theme.Fonts.Mono,
+						TextWrapped = true,
+					})
+				end
+			else
+				local newVal = formatValue(encodedValue)
+				local curVal = if instance then readCurrentValue(instance, propName) else "?"
+				table.insert(children, PropertyLine(propName, curVal, newVal))
+			end
 		end
 	end
 
@@ -185,8 +194,13 @@ local function UpdateEntry(snapshot: Types.UpdatedSnapshot, tree: any)
 	}
 end
 
-local function RemovalEntry(ref: Types.Ref, tree: any)
-	local instance = tree:getInstance(ref)
+local function RemovalEntry(object: Types.Ref | Instance, tree: any)
+	local instance
+	if typeof(object) == "Instance" then
+		instance = object
+	else
+		instance = tree:getInstance(object)
+	end
 	local name = if instance then instance.Name else "?"
 	local className = if instance then instance.ClassName else "?"
 

--- a/src/App/Widgets/Diff.luau
+++ b/src/App/Widgets/Diff.luau
@@ -10,213 +10,292 @@ local Types = require(Argon.Types)
 
 local Widget = require(Components.Plugin.Widget)
 local ScrollingContainer = require(Components.ScrollingContainer)
+local Collapsible = require(Components.Collapsible)
 local Container = require(Components.Container)
 local Padding = require(Components.Padding)
 local List = require(Components.List)
 local Text = require(Components.Text)
-local Box = require(Components.Box)
 
+local New = Fusion.New
 local Children = Fusion.Children
+local ForValues = Fusion.ForValues
+local cleanup = Fusion.cleanup
 
-local function countChildren(snapshot: Types.Snapshot): number
-	local count = 0
+local MAX_VALUE_LENGTH = 80
+
+local function countDescendants(snapshot: Types.AddedSnapshot): number
+	local descendants = 0
+
 	if snapshot.children then
-		count = #snapshot.children
-		for _, child in snapshot.children do
-			count += countChildren(child)
-		end
-	end
-	return count
-end
+		descendants = #snapshot.children
 
-local function formatValue(encoded: any): string
-	local ok, decoded = Dom.EncodedValue.decode(encoded)
-	if ok then
-		local str = tostring(decoded)
-		if #str > 80 then
-			return str:sub(1, 77) .. "..."
+		for _, child in snapshot.children do
+			descendants += countDescendants(child)
 		end
-		return str
 	end
-	return "?"
+
+	return descendants
 end
 
 local function countLines(source: string): number
-	local lines = 0
-	for _ in source:gmatch("[^\n]*\n") do
-		lines += 1
-	end
-	if not source:find("\n$") and #source > 0 then
-		lines += 1
-	end
-	return lines
+	return #source:split("\n")
 end
 
-local function countSourceLines(encoded: any): number?
-	local ok, decoded = Dom.EncodedValue.decode(encoded)
-	if ok and type(decoded) == "string" then
-		return countLines(decoded)
+local function countSnapshotLines(snapshot: Types.AddedSnapshot | Types.UpdatedSnapshot): number
+	local source = snapshot.properties and snapshot.properties.Source
+
+	if not source then
+		return 0
 	end
-	return nil
+
+	local ok, decoded = Dom.EncodedValue.decode(source)
+	return ok and countLines(decoded) or 0
 end
 
-local function readCurrentValue(instance: Instance, propertyName: string): string
-	local ok, value = Dom.readProperty(instance, propertyName)
-	if ok then
-		local str = tostring(value)
-		if #str > 80 then
-			return str:sub(1, 77) .. "..."
-		end
-		return str
+local function countInstanceLines(instance: Instance): number
+	if not instance:IsA("LuaSourceContainer") then
+		return 0
 	end
-	return "?"
+
+	local ok, source = Dom.readProperty(instance, "Source")
+	return ok and countLines(source) or 0
 end
 
-local function countCurrentSourceLines(instance: Instance, propertyName: string): number?
-	local ok, value = Dom.readProperty(instance, propertyName)
-	if ok and type(value) == "string" then
-		return countLines(value)
+local function formatValue(value: any)
+	if type(value) == "string" then
+		value = `"{value}"`
+	elseif typeof(value) == "EnumItem" then
+		value = value.Name
 	end
-	return nil
+
+	value = tostring(value)
+
+	if value:find(",") then
+		value = `({value})`
+	end
+
+	if #value > MAX_VALUE_LENGTH then
+		return value:sub(1, MAX_VALUE_LENGTH - 3) .. "..."
+	end
+
+	return value
 end
 
-local function isSourceProperty(propertyName: string): boolean
-	return propertyName == "Source"
+local function formatSnapshotValue(encoded: any, decoded: any?): string
+	local ok, value = Dom.EncodedValue.decode(encoded)
+
+	if ok and typeof(decoded) == "EnumItem" then
+		local enum = decoded.EnumType
+		value = enum:FromValue(value)
+	end
+
+	return ok and formatValue(value) or "?"
 end
 
-local function SectionHeader(text: string, color: Color3)
-	return Container {
-		Size = UDim2.fromScale(1, 0),
-		[Children] = {
-			Padding {
-				Top = 4,
-				Bottom = 4,
-			},
-			Text {
-				Font = Theme.Fonts.Bold,
-				Text = text,
-				Color = color,
-				TextSize = Theme.TextSize.Medium,
-			},
-		},
+local function formatInstanceValue(instance: Instance, property: string): (string, any?)
+	local ok, value = Dom.readProperty(instance, property)
+	return ok and formatValue(value), value or "?", nil
+end
+
+type SectionProps = {
+	Title: string,
+	Color: Color3,
+	Elements: { { any } },
+}
+
+local function Section(props: SectionProps)
+	return Collapsible {
+		Title = props.Title,
+		Color = props.Color,
+		Expanded = true,
+		Elements = ForValues(props.Elements, function(_, element)
+			return Container {
+				Size = UDim2.fromScale(1, 0),
+				[Children] = {
+					New "Frame" {
+						Size = UDim2.new(1, 0, 0, Theme.BorderThickness),
+						BackgroundColor3 = Theme.Colors.Border,
+						BorderSizePixel = 0,
+					},
+					Container {
+						Size = UDim2.fromScale(1, 1),
+						[Children] = {
+							List {
+								Spacing = 0,
+							},
+							Padding {},
+							element,
+						},
+					},
+				},
+			}
+		end, cleanup),
 	}
 end
 
-local function AdditionEntry(snapshot: Types.AddedSnapshot)
-	local childCount = countChildren(snapshot)
-	local details = ""
-	if childCount > 0 then
-		details = `  ({childCount} descendant{childCount ~= 1 and "s" or ""})`
-	end
+type TitleProps = {
+	Symbol: string,
+	Name: string,
+	Class: string,
+	Color: Color3,
+}
 
-	return Box {
-		Size = UDim2.fromScale(1, 0),
-		AutomaticSize = Enum.AutomaticSize.Y,
-		[Children] = {
-			Padding {},
-			Text {
-				Text = `+ [{snapshot.class}] "{snapshot.name}"{details}`,
-				Color = Theme.Colors.Diff.Add,
-				TextSize = Theme.TextSize.Small,
-				Font = Theme.Fonts.Mono,
-				TextWrapped = true,
-			},
-		},
-	}
-end
-
-local function PropertyLine(propertyName: string, currentValue: string, newValue: string)
+local function Title(props: TitleProps)
 	return Text {
-		Text = `    {propertyName}: {currentValue} → {newValue}`,
-		Color = Theme.Colors.TextDimmed,
+		Text = `{props.Symbol} [{props.Class}] {props.Name}`,
+		Color = props.Color,
 		TextSize = Theme.TextSize.Small,
 		Font = Theme.Fonts.Mono,
 		TextWrapped = true,
 	}
 end
 
-local function UpdateEntry(snapshot: Types.UpdatedSnapshot, tree: any)
-	local instance = tree:getInstance(snapshot.id)
-	local name = if instance then instance.Name else (snapshot.name or "?")
-	local className = if instance then instance.ClassName else (snapshot.class or "?")
+local function Property(name: string, old: any, new: any?)
+	local text
 
-	local children = {
-		Padding {},
-		List {
-			Spacing = 2,
-		},
-		Text {
-			Text = `~ [{className}] "{name}"`,
-			Color = Theme.Colors.Diff.Update,
-			TextSize = Theme.TextSize.Small,
-			Font = Theme.Fonts.Mono,
-			TextWrapped = true,
-		},
-	}
-
-	if snapshot.properties then
-		for propName, encodedValue in snapshot.properties do
-			local ty = next(encodedValue)
-			if ty == "Enum" then
-				continue
-			end
-
-			if isSourceProperty(propName) then
-				local newLines = countSourceLines(encodedValue)
-				local curLines = if instance then countCurrentSourceLines(instance, propName) else 0
-				if newLines and curLines then
-					local delta = newLines - curLines
-					local sign = if delta > 0 then "+" else ""
-					table.insert(children, Text {
-						Text = `    {propName}: {sign}{delta} line{math.abs(delta) ~= 1 and "s" or ""}`,
-						Color = Theme.Colors.TextDimmed,
-						TextSize = Theme.TextSize.Small,
-						Font = Theme.Fonts.Mono,
-						TextWrapped = true,
-					})
-				end
-			else
-				local newVal = formatValue(encodedValue)
-				local curVal = if instance then readCurrentValue(instance, propName) else "?"
-				table.insert(children, PropertyLine(propName, curVal, newVal))
-			end
-		end
+	if new then
+		text = `<b>{old}</b> → <b>{new}</b>`
+	else
+		text = `<b>{old}</b>`
 	end
 
-	if snapshot.name and instance and instance.Name ~= snapshot.name then
-		table.insert(children, PropertyLine("Name", instance.Name, snapshot.name))
-	end
-
-	return Box {
-		Size = UDim2.fromScale(1, 0),
-		AutomaticSize = Enum.AutomaticSize.Y,
-		[Children] = children,
+	return Text {
+		Text = `    {name}: {text}`,
+		Color = Theme.Colors.TextDimmed,
+		TextSize = Theme.TextSize.Small,
+		Font = Theme.Fonts.Mono,
+		TextWrapped = true,
+		RichText = true,
 	}
 end
 
-local function RemovalEntry(object: Types.Ref | Instance, tree: any)
-	local instance
-	if typeof(object) == "Instance" then
-		instance = object
-	else
-		instance = tree:getInstance(object)
-	end
-	local name = if instance then instance.Name else "?"
-	local className = if instance then instance.ClassName else "?"
+local function Additions(snapshots: { Types.AddedSnapshot }, tree: any)
+	local elements = {}
 
-	return Box {
-		Size = UDim2.fromScale(1, 0),
-		AutomaticSize = Enum.AutomaticSize.Y,
-		[Children] = {
-			Padding {},
-			Text {
-				Text = `- [{className}] "{name}"`,
-				Color = Theme.Colors.Diff.Remove,
-				TextSize = Theme.TextSize.Small,
-				Font = Theme.Fonts.Mono,
-				TextWrapped = true,
+	for _, snapshot in snapshots do
+		local parent = tree:getInstance(snapshot.parent)
+		local name = snapshot.name
+
+		if parent then
+			name = parent:GetFullName() .. "." .. name
+		end
+
+		local element = {
+			Title {
+				Symbol = "+",
+				Name = name,
+				Class = snapshot.class,
+				Color = Theme.Colors.Diff.Add,
 			},
-		},
+		}
+
+		local descendants = countDescendants(snapshot)
+		if descendants > 0 then
+			table.insert(element, Property("Descendants", descendants))
+		end
+
+		local lines = countSnapshotLines(snapshot)
+		if lines > 0 then
+			table.insert(element, Property("Lines", lines))
+		end
+
+		table.insert(elements, element)
+	end
+
+	return Section {
+		Title = `Additions ({#snapshots})`,
+		Color = Theme.Colors.Diff.Add,
+		Elements = elements,
+	}
+end
+
+local function Updates(snapshots: { Types.UpdatedSnapshot }, tree: any)
+	local elements = {}
+
+	for _, snapshot in snapshots do
+		local instance = tree:getInstance(snapshot.id)
+		local element = {
+			Title {
+				Symbol = "~",
+				Name = instance and instance:GetFullName() or snapshot.name or "?",
+				Class = instance and instance.ClassName or snapshot.class or "?",
+				Color = Theme.Colors.Diff.Update,
+			},
+		}
+
+		for property, value in snapshot.properties or {} do
+			if property ~= "Source" then
+				local formatted, raw = "?", nil
+
+				if instance then
+					formatted, raw = formatInstanceValue(instance, property)
+				end
+
+				table.insert(element, Property(property, formatted, formatSnapshotValue(value, raw)))
+
+				continue
+			end
+
+			local new = countSnapshotLines(snapshot)
+			local old = instance and countInstanceLines(instance) or 0
+			local delta = new - old
+			local sign = if delta > 0 then "+" elseif delta < 0 then "-" else "~"
+
+			delta = math.abs(delta)
+
+			table.insert(element, Property(property, `{sign}{delta} line{delta ~= 1 and "s" or ""}`))
+		end
+
+		if snapshot.name and instance and instance.Name ~= snapshot.name then
+			table.insert(element, Property("Name", instance.Name, snapshot.name))
+		end
+
+		table.insert(elements, element)
+	end
+
+	return Section {
+		Title = `Updates ({#snapshots})`,
+		Color = Theme.Colors.Diff.Update,
+		Elements = elements,
+	}
+end
+
+local function Removals(objects: { Types.Ref | Instance }, tree: any)
+	local elements = {}
+
+	for _, object in objects do
+		local instance = object
+
+		if typeof(object) == "buffer" then
+			instance = tree:getInstance(object)
+		end
+
+		local element = {
+			Title {
+				Symbol = "-",
+				Name = instance and instance:GetFullName() or "?",
+				Class = instance and instance.ClassName or "?",
+				Color = Theme.Colors.Diff.Remove,
+			},
+		}
+
+		local descendants = instance and #instance:GetDescendants() or 0
+		if descendants > 0 then
+			table.insert(element, Property("Descendants", descendants))
+		end
+
+		local lines = instance and countInstanceLines(instance) or 0
+		if lines > 0 then
+			table.insert(element, Property("Lines", lines))
+		end
+
+		table.insert(elements, element)
+	end
+
+	return Section {
+		Title = `Removals ({#objects})`,
+		Color = Theme.Colors.Diff.Remove,
+		Elements = elements,
 	}
 end
 
@@ -231,34 +310,22 @@ return function(props: Props): DockWidgetPluginGui
 	local tree = props.Tree
 	local entries = {}
 
-	-- Additions
 	if #changes.additions > 0 then
-		table.insert(entries, SectionHeader(`Additions ({#changes.additions})`, Theme.Colors.Diff.Add))
-		for _, snapshot in changes.additions do
-			table.insert(entries, AdditionEntry(snapshot))
-		end
+		table.insert(entries, Additions(changes.additions, tree))
 	end
 
-	-- Updates
 	if #changes.updates > 0 then
-		table.insert(entries, SectionHeader(`Updates ({#changes.updates})`, Theme.Colors.Diff.Update))
-		for _, snapshot in changes.updates do
-			table.insert(entries, UpdateEntry(snapshot, tree))
-		end
+		table.insert(entries, Updates(changes.updates, tree))
 	end
 
-	-- Removals
 	if #changes.removals > 0 then
-		table.insert(entries, SectionHeader(`Removals ({#changes.removals})`, Theme.Colors.Diff.Remove))
-		for _, ref in changes.removals do
-			table.insert(entries, RemovalEntry(ref, tree))
-		end
+		table.insert(entries, Removals(changes.removals, tree))
 	end
 
 	return Widget {
 		Name = "Argon - Diff",
 		OverrideEnabled = true,
-		MinimumSize = Vector2.new(450, 400),
+		MinimumSize = Vector2.new(500, 400),
 		Closed = props.Closed,
 
 		[Children] = {
@@ -270,9 +337,7 @@ return function(props: Props): DockWidgetPluginGui
 				ScrollBar = true,
 
 				[Children] = {
-					List {
-						Spacing = 6,
-					},
+					List {},
 					Padding {
 						Padding = Theme.WidgetPadding,
 					},

--- a/src/App/init.luau
+++ b/src/App/init.luau
@@ -42,6 +42,7 @@ local Error = require(Pages.Error)
 
 local Settings = require(Widgets.Settings)
 local Help = require(Widgets.Help)
+local Diff = require(Widgets.Diff)
 
 local New = Fusion.New
 local Value = Fusion.Value
@@ -80,6 +81,7 @@ function App.new()
 
 	self.settingsWidget = Value(nil)
 	self.helpWidget = Value(nil)
+	self.diffWidget = Value(nil)
 
 	local isOpen = Value(false)
 
@@ -314,7 +316,7 @@ function App:connect()
 		canceled = true
 	end)
 
-	self.core:onPrompt(function(message, changes)
+	self.core:onPrompt(function(message, changes, tree)
 		loading = false
 
 		local signal = Signal.new()
@@ -337,9 +339,34 @@ function App:connect()
 			local choice = signal:Wait()
 
 			while choice == "Diff" do
-				warn("This feature is not yet implemented!")
-				print("You can see raw changes here:", changes)
+				local widget = peek(self.diffWidget)
+
+				if widget then
+					widget:Destroy()
+					self.diffWidget:set(nil)
+				else
+					widget = Diff {
+						Changes = changes,
+						Tree = tree,
+						Closed = function()
+							local w = peek(self.diffWidget)
+							if w then
+								w:Destroy()
+								self.diffWidget:set(nil)
+							end
+						end,
+					}
+					self.diffWidget:set(widget)
+				end
+
 				choice = signal:Wait()
+			end
+
+			-- Close diff widget when user accepts or cancels
+			local widget = peek(self.diffWidget)
+			if widget then
+				widget:Destroy()
+				self.diffWidget:set(nil)
 			end
 
 			result = choice == "Accept"

--- a/src/App/init.luau
+++ b/src/App/init.luau
@@ -16,6 +16,7 @@ local Signal = require(Packages.Signal)
 
 local manifest = require(Argon.manifest)
 local Config = require(Argon.Config)
+local Types = require(Argon.Types)
 local Util = require(Argon.Util)
 local Core = require(Argon.Core)
 local describeChanges = require(Helpers.describeChanges)
@@ -295,6 +296,26 @@ function App:help()
 	self.helpWidget:set(widget)
 end
 
+function App:diff(changes: Types.Changes?, tree: any?)
+	local widget = peek(self.diffWidget)
+
+	if widget then
+		widget:Destroy()
+		widget = nil
+	elseif changes and tree then
+		widget = Diff {
+			Changes = changes,
+			Tree = tree,
+			Closed = function()
+				peek(self.diffWidget):Destroy()
+				self.diffWidget:set(nil)
+			end,
+		}
+	end
+
+	self.diffWidget:set(widget)
+end
+
 function App:connect()
 	local project = Value({})
 	local canceled = false
@@ -339,35 +360,11 @@ function App:connect()
 			local choice = signal:Wait()
 
 			while choice == "Diff" do
-				local widget = peek(self.diffWidget)
-
-				if widget then
-					widget:Destroy()
-					self.diffWidget:set(nil)
-				else
-					widget = Diff {
-						Changes = changes,
-						Tree = tree,
-						Closed = function()
-							local w = peek(self.diffWidget)
-							if w then
-								w:Destroy()
-								self.diffWidget:set(nil)
-							end
-						end,
-					}
-					self.diffWidget:set(widget)
-				end
-
+				self:diff(changes, tree)
 				choice = signal:Wait()
 			end
 
-			-- Close diff widget when user accepts or cancels
-			local widget = peek(self.diffWidget)
-			if widget then
-				widget:Destroy()
-				self.diffWidget:set(nil)
-			end
+			self:diff()
 
 			result = choice == "Accept"
 		-- Prompt user whether to continue when server ID differs

--- a/src/Core/init.luau
+++ b/src/Core/init.luau
@@ -48,7 +48,7 @@ function Core.new(host: string?, port: string?)
 	self.watcher = Watcher.new()
 	self.executor = Executor.new()
 
-	self.__prompt = function(_message: string, _changes: Types.Changes?): boolean
+	self.__prompt = function(_message: string, _changes: Types.Changes?, _tree: any): boolean
 		return true
 	end
 	self.__ready = function(_project: Types.Project) end
@@ -159,13 +159,13 @@ function Core:stop()
 	Util.clean(self.connections)
 end
 
-function Core:onPrompt(callback: (message: string, changes: Types.Changes?) -> boolean)
+function Core:onPrompt(callback: (message: string, changes: Types.Changes?, tree: any) -> boolean)
 	self.__prompt = function(message, changes)
 		if self.status == Core.Status.Disconnecting then
 			return false
 		end
 
-		return callback(message, changes)
+		return callback(message, changes, self.tree)
 	end
 end
 


### PR DESCRIPTION
  Added the missing Diff function that shows up when you click "Diff" during the change verification prompt. Before this it just printed a warning that the feature wasn't implemented yet.

  Now it opens a separate dock widget window that shows all incoming changes grouped by type:
  - Additions in green with descendant count
  - Updates in blue with property comparisons (old vs new value)
  - Removals in red

  For script Source properties it shows line counts instead of dumping the whole source code. The widget closes automatically when you accept
  or cancel.

  - `src/App/Widgets/Diff.luau` - the new widget
  - `src/App/init.luau` - hooked up the Diff button to open/close the widget
  - `src/Core/init.luau` - pass the Tree to the prompt callback so the widget can look up instance names and current values