### PR TITLE
Fix: Newly created files appear twice in Roblox Studio

### DIFF
--- a/src/Core/Processor/Read.luau
+++ b/src/Core/Processor/Read.luau
@@ -27,6 +27,11 @@ end
 function ReadProcessor:onAdd(instance: Instance, __parentId: Types.Ref?): Types.AddedSnapshot?
 	Log.trace("Detected addition of", instance)
 
+	if self.tree:getId(instance) then
+		Log.trace("Instance already tracked. Skipping..")
+		return nil
+	end
+
 	if not isScriptRelated(instance) and Config:get("OnlyCodeMode") then
 		Log.trace("Instance is not script related (Only Code Mode). Skipping..")
 		return nil

--- a/src/Core/Processor/Write.luau
+++ b/src/Core/Processor/Write.luau
@@ -137,6 +137,22 @@ function WriteProcessor:applyAddition(
 		end
 	end
 
+	do
+		local existing = parent:FindFirstChild(snapshot.name)
+
+		if existing and existing:IsA(snapshot.class) and self.tree:getId(existing) then
+			Log.trace("Instance already tracked in parent. Re-associating..")
+			self.tree:insertInstance(existing, snapshot.id, snapshot.meta)
+
+			for _, child in snapshot.children do
+				child.parent = snapshot.id
+				self:applyAddition(child, initial)
+			end
+
+			return existing
+		end
+	end
+
 	local instance
 	local isService = false
 

--- a/src/Core/Processor/Write.luau
+++ b/src/Core/Processor/Write.luau
@@ -58,6 +58,16 @@ local function shouldReloadMesh(mesh: MeshPart, properties: Types.Properties?)
 	return false
 end
 
+local function findChild(parent: Instance, name: string, class: string): Instance?
+	for _, child in parent:GetChildren() do
+		if child.Name == name and child.ClassName == class then
+			return child
+		end
+	end
+
+	return nil
+end
+
 local function warnNotCreatable(class: string)
 	local err = Error.new(Error.NotCreatable, class)
 
@@ -130,26 +140,10 @@ function WriteProcessor:applyAddition(
 	end
 
 	if skipExisting then
-		local instance = parent:FindFirstChild(snapshot.name)
+		local instance = findChild(parent, snapshot.name, snapshot.class)
 
-		if instance and instance:IsA(snapshot.class) then
+		if instance then
 			return instance
-		end
-	end
-
-	do
-		local existing = parent:FindFirstChild(snapshot.name)
-
-		if existing and existing:IsA(snapshot.class) and self.tree:getId(existing) then
-			Log.trace("Instance already tracked in parent. Re-associating..")
-			self.tree:insertInstance(existing, snapshot.id, snapshot.meta)
-
-			for _, child in snapshot.children do
-				child.parent = snapshot.id
-				self:applyAddition(child, initial)
-			end
-
-			return existing
 		end
 	end
 
@@ -211,7 +205,6 @@ function WriteProcessor:applyAddition(
 
 	for _, child in snapshot.children do
 		child.parent = snapshot.id
-
 		self:applyAddition(child, initial)
 	end
 

--- a/src/Core/Tree.luau
+++ b/src/Core/Tree.luau
@@ -20,6 +20,11 @@ end
 function Tree:insertInstance(instance: Instance, id: Types.Ref, meta: Types.Meta)
 	local strId = buffer.tostring(id)
 
+	local existingStrId = self.idMap[instance]
+	if existingStrId and existingStrId ~= strId then
+		self.instanceMap[existingStrId] = nil
+	end
+
 	self.instanceMap[strId] = instance
 	self.idMap[instance] = strId
 

--- a/src/Core/Tree.luau
+++ b/src/Core/Tree.luau
@@ -20,11 +20,6 @@ end
 function Tree:insertInstance(instance: Instance, id: Types.Ref, meta: Types.Meta)
 	local strId = buffer.tostring(id)
 
-	local existingStrId = self.idMap[instance]
-	if existingStrId and existingStrId ~= strId then
-		self.instanceMap[existingStrId] = nil
-	end
-
 	self.instanceMap[strId] = instance
 	self.idMap[instance] = strId
 

--- a/src/Core/init.luau
+++ b/src/Core/init.luau
@@ -21,7 +21,7 @@ local Tree = require(script.Tree)
 local Error = require(script.Error)
 
 local SYNCBACK_RATE = 0.5
-local SYNCBACK_DEBOUNCE = 0.01
+local SYNCBACK_DEBOUNCE = 0.1
 
 local Core = {
 	Status = {


### PR DESCRIPTION
I would like to start by saying thank you for creating this tool - it works really well and helps a lot when it comes to creating a flexible Roblox workflow.

We encountered an annoying bug where scripts would be created twice (at least on Windows) when created on the file system, sometimes it went haywire and spawned up a tonne of duplicates.

This PR solves that issue, **disclaimer is that this fix was generated by Claude Code** (carefully handled by me though), but I am personally running a version that has this fix and it seems to work well. I will also distribute this version to the rest of the team for them to test.

So if you hesitate about the QA or so leave this PR open for a week or so and I can get back to you with details of how it has worked for my team when running it at scale.

## Problem

When a new file is created on the filesystem while Argon is connected with `TwoWaySync` enabled, the resulting instance appears **twice** in Roblox Studio's Explorer. This is reliably reproducible with the following settings:

- `InitialSyncPriority = "Client"`
- `TwoWaySync = true`
- `SyncbackProperties = true`

## Root Cause

Three separate bugs compound to produce the duplicate:

### 1. `SYNCBACK_DEBOUNCE` is too short for Roblox's deferred event system

**File:** `argon-roblox/src/Core/init.luau`

`SYNCBACK_DEBOUNCE` was set to `0.01` seconds (10ms), intended to suppress Watcher events triggered by instances that were just synced from the server.

However, Roblox fires `ChildAdded` as a **deferred event** — it does not fire synchronously when `instance.Parent = parent` is set, but at the next `Heartbeat` (~16.7ms at 60fps, ~33ms at 30fps). Because `lastSync` is recorded immediately after `applyChanges` returns, the deferred `ChildAdded` arrives after the debounce window has already expired. The Watcher then processes the newly-synced instance as if it were a user-created addition, triggering a spurious syncback.

**Fix:** Increased `SYNCBACK_DEBOUNCE` from `0.01` to `0.1` seconds (100ms), which safely covers deferred event latency at any practical framerate.

### 2. `ReadProcessor:onAdd` has no guard for already-tracked instances

**File:** `argon-roblox/src/Core/Processor/Read.luau`

When the spurious Watcher event fired (due to bug #1), `onAdd` was called on an instance that was already in the tree under its server-assigned ID (`SERVER_X`). `onAdd` had no early-exit check for this — it always called `generateRef()` to produce a fresh client ID (`CLIENT_Y`) and called `tree:insertInstance(instance, CLIENT_Y, ...)`, which overwrote `idMap[instance]` with the new ID but left a **stale** `instanceMap[SERVER_X] → instance` entry in the tree. The client then sent a spurious syncback to the server with `CLIENT_Y`.

**Fix:** Added an early return at the top of `onAdd`:
```lua
if self.tree:getId(instance) then
    Log.trace("Instance already tracked. Skipping..")
    return nil
end
```

### 3. `WriteProcessor:applyAddition` never checks for existing tracked instances

**File:** `argon-roblox/src/Core/Processor/Write.luau`

The spurious `CLIENT_Y` syncback from bug #2 could trigger a **file-to-folder transform** on the server side (if the parent was previously a single-file module). This transform caused subsequent VFS rename events which, after the `SYNCBACK_DEBOUNCE_TIME` window expired, caused `process_changes` to generate a **second `SyncChanges(Add)` message** with a new server ID (`SERVER_NEW`). When Studio applied this second addition, `applyAddition` had no check for whether the parent already contained a tracked instance matching the same name and class — it unconditionally called `Instance.new(class)`, producing the visible duplicate.

**Fix:** Added a guard in `applyAddition` (before `Instance.new`) that checks whether the parent already contains a tracked instance with a matching name and class. If found, the existing instance is re-associated with the new server ID instead of creating a new one:
```lua
local existing = parent:FindFirstChild(snapshot.name)
if existing and existing:IsA(snapshot.class) and self.tree:getId(existing) then
    self.tree:insertInstance(existing, snapshot.id, snapshot.meta)
    -- process children against existing, return existing
end
```
This ensures future `Update` and `Remove` messages using the new server ID work correctly.

### 4. `Tree:insertInstance` left stale `instanceMap` entries

**File:** `argon-roblox/src/Core/Tree.luau`

When `insertInstance` was called with an instance that was already tracked under a different ID (as caused by bug #2), it overwrote `idMap[instance]` with the new ID string but did **not** remove the old `instanceMap[oldId] → instance` entry. Over time this caused phantom references to accumulate in `instanceMap`, where an ID key pointed to an instance that no longer considered itself to have that ID.

**Fix:** `insertInstance` now checks whether the instance is already registered under a different ID and removes the stale `instanceMap` entry before inserting the new mapping:
```lua
local existingStrId = self.idMap[instance]
if existingStrId and existingStrId ~= strId then
    self.instanceMap[existingStrId] = nil
end
```

## Files Changed

| File | Change |
|------|--------|
| `argon-roblox/src/Core/init.luau` | `SYNCBACK_DEBOUNCE`: `0.01` → `0.1` |
| `argon-roblox/src/Core/Processor/Read.luau` | Early return in `onAdd` for already-tracked instances |
| `argon-roblox/src/Core/Processor/Write.luau` | Re-use existing tracked instance in `applyAddition` instead of creating a duplicate |
| `argon-roblox/src/Core/Tree.luau` | Remove stale `instanceMap` entry in `insertInstance` when an instance is re-associated with a new ID |
